### PR TITLE
Fix: Create Assistants + Get assistants

### DIFF
--- a/my-app/app/dashboard/assistants/page.tsx
+++ b/my-app/app/dashboard/assistants/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Metadata } from 'next';
-import Assistants from '@/app/dashboard/assistants/assistants';
+import Assistants from '@/components/Assistants';
 
 export const metadata: Metadata = {
   title: 'Assistants | Dashboard',

--- a/my-app/components/Workground.tsx
+++ b/my-app/components/Workground.tsx
@@ -37,7 +37,6 @@ export default function Workground() {
   const [widgetName, setWidgetName] = useState<string>("Elli");
   const [avatarUrl, setAvatarUrl] = useState<string>("/Avatar.png");
   const [brandColor, setBrandColor] = useState<string>("#007fff");
-  const [customInstructions, setCustomInstructions] = useState<string>("");
   const [greetingMessage, setGreetingMessage] = useState<string>("Hello! I'm Elli, Ask me anything about Intelli?");
   const [showWelcomeDialog, setShowWelcomeDialog] = useState<boolean>(true);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -87,7 +86,6 @@ export default function Workground() {
       widgetName,
       avatarUrl,
       brandColor,
-      customInstructions,
       greetingMessage,
     };
 
@@ -211,15 +209,6 @@ export default function Workground() {
                   placeholder="#007fff"
                 />
               </div>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-foreground mb-1">Custom Instructions</label>
-              <Textarea 
-                value={customInstructions} 
-                onChange={(e) => setCustomInstructions(e.target.value)}
-                placeholder="Enter custom instructions for your assistant"
-                className="h-24"
-              />
             </div>
             <div>
               <label className="block text-sm font-medium text-foreground mb-1">Greeting Message</label>

--- a/my-app/components/create-assistant-dialog.tsx
+++ b/my-app/components/create-assistant-dialog.tsx
@@ -39,10 +39,10 @@ export function CreateAssistantDialog({ onAssistantCreated }: CreateAssistantDia
   const { toast } = useToast();
 
   useEffect(() => {
-    if (isLoaded && userMemberships?.data?.length > 0) {
+    if (isLoaded && userMemberships?.data?.length > 0 && !selectedOrganizationId) {
       setSelectedOrganizationId(userMemberships.data[0].organization.id);
     }
-  }, [isLoaded, userMemberships]);
+  }, [isLoaded, userMemberships, selectedOrganizationId]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -109,10 +109,9 @@ export function CreateAssistantDialog({ onAssistantCreated }: CreateAssistantDia
             <label className="block text-sm font-medium text-foreground mb-1">Organization</label>
             <Select
               value={selectedOrganizationId}
-              onValueChange={setSelectedOrganizationId}
-              disabled={!isLoaded}
+              onValueChange={(value) => setSelectedOrganizationId(value)}
             >
-              <SelectTrigger>
+              <SelectTrigger className="w-full">
                 <SelectValue placeholder="Select an organization" />
               </SelectTrigger>
               <SelectContent>
@@ -151,3 +150,4 @@ export function CreateAssistantDialog({ onAssistantCreated }: CreateAssistantDia
     </Dialog>
   );
 }
+

--- a/my-app/services/assistant-service.ts
+++ b/my-app/services/assistant-service.ts
@@ -1,0 +1,14 @@
+export async function fetchAssistantsByOrganization(organizationId: string) {
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/assistants/${organizationId}/`)
+      if (!response.ok) {
+        throw new Error('Failed to fetch assistants')
+      }
+      return await response.json()
+    } catch (error) {
+      console.error('Error fetching assistants:', error)
+      return []
+    }
+  }
+  
+  


### PR DESCRIPTION
This new PR has updates

1. New logic to enable fetching assistants by Organisation
2. Create Assistant dialog has enabled org selection in dropdown
3. Playground page removed Custom instructions field
4. Refactored look of assistants page
5. Changed import path of assistant