### PR TITLE
Fix Build error: Build nmigc9o55

### DIFF
--- a/my-app/components/widget-communication.tsx
+++ b/my-app/components/widget-communication.tsx
@@ -10,6 +10,7 @@ import { Send, X } from 'lucide-react';
 import { toast } from "sonner";
 
 interface WidgetCommunicationProps {
+  widgetKey: string;
   widgetName: string;
   avatarUrl: string;
   brandColor: string;


### PR DESCRIPTION
add missing widget key to props to solve error

```./components/Workground.tsx:291:11
Type error: Type '{ widgetKey: string; widgetName: string; avatarUrl: string; brandColor: string; 

greetingMessage: string; }' is not assignable to type 'IntrinsicAttributes & WidgetCommunicationProps'.
```