### PR TITLE
send message fix; media header

### DIFF
--- a/my-app/components/test-message-dialog.tsx
+++ b/my-app/components/test-message-dialog.tsx
@@ -9,6 +9,8 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { toast } from 'sonner';
 import { type WhatsAppTemplate } from '@/services/whatsapp';
 import { WhatsAppService } from '@/services/whatsapp';
+import { metaConfigService } from '@/services/meta-config';
+import { Upload, Image as ImageIcon, Video, FileText } from 'lucide-react';
 
 interface TestMessageDialogProps {
   template: WhatsAppTemplate | null;
@@ -20,7 +22,12 @@ interface TestMessageDialogProps {
 export default function TestMessageDialog({ template, appService, isOpen, onClose }: TestMessageDialogProps) {
   const [phoneNumber, setPhoneNumber] = useState('');
   const [variables, setVariables] = useState<string[]>([]);
+  const [headerMediaFile, setHeaderMediaFile] = useState<File | null>(null);
+  const [headerMediaHandle, setHeaderMediaHandle] = useState<string>('');
+  const [isUploadingMedia, setIsUploadingMedia] = useState(false);
   const [isSending, setIsSending] = useState(false);
+
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   React.useEffect(() => {
     if (template) {
@@ -35,12 +42,84 @@ export default function TestMessageDialog({ template, appService, isOpen, onClos
           })
         );
         
-        // Create array based on highest variable number (e.g., {{1}}, {{3}} = 3 variables)
+        // Create array based on highest variable number
         const maxVariableNum = uniqueVariables.size > 0 ? Math.max(...Array.from(uniqueVariables)) : 0;
         setVariables(new Array(maxVariableNum).fill(''));
       }
+
+      // Reset media state when template changes
+      setHeaderMediaFile(null);
+      setHeaderMediaHandle('');
     }
   }, [template]);
+
+  // Check if template has media header
+  const getHeaderMediaType = () => {
+    const headerComponent = template?.components?.find(c => c.type === 'HEADER');
+    if (headerComponent?.format && ['IMAGE', 'VIDEO', 'DOCUMENT'].includes(headerComponent.format)) {
+      return headerComponent.format;
+    }
+    return undefined;
+  };
+
+  const uploadMediaToMeta = async (file: File): Promise<string> => {
+    try {
+      setIsUploadingMedia(true);
+      
+      const config = await metaConfigService.getConfigForAppService(appService);
+      if (!config) {
+        throw new Error('Could not get Meta app configuration');
+      }
+
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('appId', config.appId);
+      formData.append('accessToken', config.accessToken);
+
+      const response = await fetch('/api/whatsapp/upload-media', {
+        method: 'POST',
+        body: formData
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to upload media');
+      }
+
+      const data = await response.json();
+      console.log('Media upload response:', data);
+      
+      if (!data.handle) {
+        throw new Error('Media upload succeeded but no handle was returned');
+      }
+      
+      return data.handle;
+    } catch (error) {
+      console.error('Meta upload error:', error);
+      throw error;
+    } finally {
+      setIsUploadingMedia(false);
+    }
+  };
+
+  const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const mediaType = getHeaderMediaType();
+    if (!mediaType) return;
+
+    setHeaderMediaFile(file);
+
+    try {
+      const handle = await uploadMediaToMeta(file);
+      setHeaderMediaHandle(handle);
+      toast.success('Media uploaded successfully');
+    } catch (error) {
+      toast.error('Failed to upload media');
+      setHeaderMediaFile(null);
+    }
+  };
 
   const handleSendTest = async () => {
     if (!template || !appService) return;
@@ -57,9 +136,63 @@ export default function TestMessageDialog({ template, appService, isOpen, onClos
       return;
     }
 
+    // Check if media is required but not uploaded
+    const mediaType = getHeaderMediaType();
+    if (mediaType && !headerMediaHandle) {
+      toast.error(`Please upload ${mediaType.toLowerCase()} for the template header`);
+      return;
+    }
+
     setIsSending(true);
 
     try {
+      const components = [];
+
+      // Add header component if template has media header
+      if (mediaType && headerMediaHandle) {
+        const headerComponent: any = {
+          type: "header",
+          parameters: []
+        };
+
+        if (mediaType === 'IMAGE') {
+          headerComponent.parameters.push({
+            type: "image",
+            image: {
+              id: headerMediaHandle  // Use the handle as media ID
+            }
+          });
+        } else if (mediaType === 'VIDEO') {
+          headerComponent.parameters.push({
+            type: "video",
+            video: {
+              id: headerMediaHandle
+            }
+          });
+        } else if (mediaType === 'DOCUMENT') {
+          headerComponent.parameters.push({
+            type: "document",
+            document: {
+              id: headerMediaHandle,
+              filename: headerMediaFile?.name || "document.pdf"
+            }
+          });
+        }
+
+        components.push(headerComponent);
+      }
+
+      // Add body component if there are variables
+      if (variables.length > 0) {
+        components.push({
+          type: "body",
+          parameters: variables.map(value => ({
+            type: "text",
+            text: value || `Sample Value ${variables.indexOf(value) + 1}`
+          }))
+        });
+      }
+
       const messageData = {
         messaging_product: "whatsapp",
         to: cleanNumber,
@@ -69,17 +202,11 @@ export default function TestMessageDialog({ template, appService, isOpen, onClos
           language: {
             code: template.language
           },
-          components: variables.length > 0 ? [
-            {
-              type: "body",
-              parameters: variables.map(value => ({
-                type: "text",
-                text: value || `Sample Value ${variables.indexOf(value) + 1}`
-              }))
-            }
-          ] : undefined
+          components: components.length > 0 ? components : undefined
         }
       };
+
+      console.log('Sending message with data:', messageData);
 
       await WhatsAppService.sendMessage(
         appService,
@@ -88,8 +215,12 @@ export default function TestMessageDialog({ template, appService, isOpen, onClos
 
       toast.success("Test message sent successfully!");
       onClose();
+      
+      // Reset form
       setPhoneNumber('');
       setVariables([]);
+      setHeaderMediaFile(null);
+      setHeaderMediaHandle('');
     } catch (error) {
       console.error('Send test message error:', error);
       toast.error("Failed to send test message");
@@ -105,6 +236,13 @@ export default function TestMessageDialog({ template, appService, isOpen, onClos
   };
 
   if (!template) return null;
+
+  const mediaType = getHeaderMediaType();
+  const acceptedFormats = {
+    IMAGE: 'image/jpeg,image/png',
+    VIDEO: 'video/mp4',
+    DOCUMENT: 'application/pdf'
+  };
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -135,6 +273,67 @@ export default function TestMessageDialog({ template, appService, isOpen, onClos
               Include country code (e.g., +1 for US)
             </p>
           </div>
+
+          {/* Media upload section for templates with media headers */}
+          {mediaType && (
+            <div className="space-y-2">
+              <Label>Template Header Media ({mediaType}) *</Label>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={acceptedFormats[mediaType as keyof typeof acceptedFormats]}
+                onChange={handleFileUpload}
+                className="hidden"
+              />
+              
+              {headerMediaFile ? (
+                <div className="flex items-center justify-between p-3 border rounded-lg">
+                  <div className="flex items-center gap-2">
+                    {mediaType === 'IMAGE' && <ImageIcon className="h-4 w-4" />}
+                    {mediaType === 'VIDEO' && <Video className="h-4 w-4" />}
+                    {mediaType === 'DOCUMENT' && <FileText className="h-4 w-4" />}
+                    <span className="text-sm">{headerMediaFile.name}</span>
+                    {headerMediaHandle && (
+                      <span className="text-xs text-green-600">✓ Uploaded</span>
+                    )}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setHeaderMediaFile(null);
+                      setHeaderMediaHandle('');
+                    }}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isUploadingMedia}
+                >
+                  {isUploadingMedia ? (
+                    <>Uploading...</>
+                  ) : (
+                    <>
+                      <Upload className="h-4 w-4 mr-2" />
+                      Upload {mediaType.toLowerCase()}
+                    </>
+                  )}
+                </Button>
+              )}
+              
+              <p className="text-xs text-muted-foreground">
+                {mediaType === 'IMAGE' && 'Supported: JPG, PNG (max 5MB)'}
+                {mediaType === 'VIDEO' && 'Supported: MP4 (max 16MB)'}
+                {mediaType === 'DOCUMENT' && 'Supported: PDF (max 100MB)'}
+              </p>
+            </div>
+          )}
 
           {variables.length > 0 && (
             <div className="space-y-2">
@@ -169,7 +368,7 @@ export default function TestMessageDialog({ template, appService, isOpen, onClos
                 {template.components?.map((component, index) => (
                   <div key={index} className="mb-2">
                     <div className="font-medium text-xs text-gray-500 uppercase">{component.type}</div>
-                    <div>{component.text}</div>
+                    <div>{component.text || (component.format ? `[${component.format}]` : '')}</div>
                   </div>
                 ))}
               </div>
@@ -182,7 +381,7 @@ export default function TestMessageDialog({ template, appService, isOpen, onClos
             </Button>
             <Button 
               onClick={handleSendTest} 
-              disabled={isSending || template.status !== 'APPROVED'}
+              disabled={isSending || template.status !== 'APPROVED' || (mediaType && !headerMediaHandle)}
             >
               {isSending ? "Sending..." : "Send Test"}
             </Button>


### PR DESCRIPTION
# PR Description
**Media upload and handling improvements:**

* Added state and handlers to manage media file selection, upload status, and storage of the uploaded media handle (`headerMediaHandle`). Media files are uploaded to Meta via a new async function, and errors are handled gracefully with user feedback. [[1]](diffhunk://#diff-0cb96f959866b27c62d58185593120f03ae65ade534adeace77611686e8286aaR25-R31) [[2]](diffhunk://#diff-0cb96f959866b27c62d58185593120f03ae65ade534adeace77611686e8286aaL38-R123)
* The UI now displays an upload section for templates with media headers, including accepted format hints, upload progress, and the ability to remove or re-upload files.
* The send button is disabled until required media is uploaded, ensuring users cannot send incomplete messages.

**Message construction changes:**

* When sending a test message, the code now constructs the `components` array dynamically, including a header component with the uploaded media if required, and a body component with template variables. [[1]](diffhunk://#diff-0cb96f959866b27c62d58185593120f03ae65ade534adeace77611686e8286aaR139-R195) [[2]](diffhunk://#diff-0cb96f959866b27c62d58185593120f03ae65ade534adeace77611686e8286aaL72-R223)

**Template and UI enhancements:**

* The template preview now displays the media format if no text is present for a component, improving clarity for users.
* Media state is reset when the template changes or after sending a message, preventing stale data from persisting. [[1]](diffhunk://#diff-0cb96f959866b27c62d58185593120f03ae65ade534adeace77611686e8286aaL38-R123) [[2]](diffhunk://#diff-0cb96f959866b27c62d58185593120f03ae65ade534adeace77611686e8286aaL72-R223)

**Dependency updates:**

* Imported new icons (`Upload`, `ImageIcon`, `Video`, `FileText`) and the `metaConfigService` for use in the media upload workflow.