### PR TITLE
Retrieve Media ID from uploaded media

### DIFF
--- a/my-app/app/api/whatsapp/upload-media/route.ts
+++ b/my-app/app/api/whatsapp/upload-media/route.ts
@@ -6,7 +6,8 @@ export async function POST(request: NextRequest) {
     const formData = await request.formData();
     const file = formData.get('file') as File;
     const accessToken = formData.get('accessToken') as string;
-    const appId = formData.get('appId') as string;
+    const appId = formData.get('appId') as string; // This is the App ID for upload session
+    const phoneNumberId = formData.get('phoneNumberId') as string; // Phone number ID for media endpoint
 
     if (!file || !accessToken || !appId) {
       return NextResponse.json(
@@ -83,11 +84,41 @@ export async function POST(request: NextRequest) {
     const uploadData = await uploadResponse.json();
     
     console.log('Upload successful, handle:', uploadData.h);
+
+    // Step 3: Get the media ID from the uploaded media
+    // Use the standard media upload API to get the media ID
+    const mediaFormData = new FormData();
+    mediaFormData.append('messaging_product', 'whatsapp');
+    mediaFormData.append('file', new Blob([buffer], { type: file.type }), file.name);
+
+    // Use phone number ID for the media endpoint if available, otherwise fallback to appId
+    const mediaEndpointId = phoneNumberId || appId;
+    const mediaResponse = await fetch(`https://graph.facebook.com/v23.0/${mediaEndpointId}/media`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`
+      },
+      body: mediaFormData
+    });
+
+    if (!mediaResponse.ok) {
+      const error = await mediaResponse.json();
+      console.error('Media ID fetch error:', error);
+      return NextResponse.json(
+        { error: error.error?.message || 'Failed to get media ID' },
+        { status: mediaResponse.status }
+      );
+    }
+
+    const mediaData = await mediaResponse.json();
     
-    // Return the media handle (h field)
+    console.log('Media ID obtained:', mediaData.id);
+    
+    // Return both the resumable upload handle and the media ID
     return NextResponse.json({ 
       success: true, 
-      handle: uploadData.h, // This is what will be used in template creation
+      handle: uploadData.h, // Resumable upload handle
+      mediaId: mediaData.id, // Media ID for template messages
       sessionId: uploadSessionId,
       fileType: file.type,
       fileName: file.name

--- a/my-app/components/create-template-form.tsx
+++ b/my-app/components/create-template-form.tsx
@@ -271,7 +271,8 @@ export default function CreateTemplateForm({ onClose, onSubmit, loading = false,
   
       const formData = new FormData()
       formData.append('file', file)
-      formData.append('appId', config.appId)
+      formData.append('appId', config.appId) // Use App ID for upload session
+      formData.append('phoneNumberId', appService.phone_number_id) // Phone number ID for media endpoint
       formData.append('accessToken', config.accessToken)
   
       const response = await fetch('/api/whatsapp/upload-media', {
@@ -288,14 +289,14 @@ export default function CreateTemplateForm({ onClose, onSubmit, loading = false,
       
       // Debug logging
       console.log('Media upload response:', data)
-      console.log('Media handle (uploadData.h):', data.handle)
+      console.log('Media ID for template messages:', data.mediaId)
       
-      // Use the handle field which contains uploadData.h from the API response
-      const mediaHandle = data.handle
+      // Use the mediaId field for template messages
+      const mediaHandle = data.mediaId
       
       if (!mediaHandle) {
-        console.error('No valid handle found in response:', data)
-        throw new Error('Media upload succeeded but no handle was returned')
+        console.error('No valid media ID found in response:', data)
+        throw new Error('Media upload succeeded but no media ID was returned')
       }
       
       return mediaHandle

--- a/my-app/components/customize-template-dialog.tsx
+++ b/my-app/components/customize-template-dialog.tsx
@@ -256,7 +256,8 @@ export function CustomizeTemplateDialog({
       // Use the backend API to upload the file
       const formData = new FormData();
       formData.append('file', file);
-      formData.append('appId', config.appId);
+      formData.append('appId', config.appId); // Use App ID for upload session
+      formData.append('phoneNumberId', appService.phone_number_id); // Phone number ID for media endpoint
       formData.append('accessToken', config.accessToken);
 
       const response = await fetch('/api/whatsapp/upload-media', {
@@ -273,10 +274,10 @@ export function CustomizeTemplateDialog({
       
       // Debug logging
       console.log('Media upload response:', data);
-      console.log('Media handle (uploadData.h):', data.handle);
+      console.log('Media ID for template messages:', data.mediaId);
       
-      // Use the handle field which contains uploadData.h from the API response
-      return data.handle;
+      // Use the mediaId field for template messages
+      return data.mediaId;
     } catch (error) {
       console.error('Meta upload error:', error);
       throw error;


### PR DESCRIPTION
# PR Description

**Backend API improvements:**

* The `/api/whatsapp/upload-media` endpoint now accepts and uses both `appId` (for upload session) and `phoneNumberId` (for the media endpoint), and returns both the resumable upload handle and the actual media ID required for template messages. [[1]](diffhunk://#diff-c98e467c868d41ffa179a14dd55c44e064a60a60def18b8fe9f60af443c71fb0L9-R10) [[2]](diffhunk://#diff-c98e467c868d41ffa179a14dd55c44e064a60a60def18b8fe9f60af443c71fb0L87-R121)

**Frontend form and dialog updates:**

* All frontend components (`CreateTemplateForm`, `CustomizeTemplateDialog`, and `TestMessageDialog`) now send both `appId` and `phoneNumberId` to the backend when uploading media. [[1]](diffhunk://#diff-f0e69cf15e3b35becc976e7c8f4a6cc45318a6d63acbdcae932aa634f9987b4aL274-R275) [[2]](diffhunk://#diff-423a6db60de7891cceac2baf1fa96d5f2bc2417f78d456af62b4203ab9db3dcbL259-R260) [[3]](diffhunk://#diff-0cb96f959866b27c62d58185593120f03ae65ade534adeace77611686e8286aaL76-R77)
* The frontend now uses the `mediaId` returned from the backend (instead of the upload handle) for template messages, with updated variable names and error handling to reflect this change. [[1]](diffhunk://#diff-f0e69cf15e3b35becc976e7c8f4a6cc45318a6d63acbdcae932aa634f9987b4aL291-R299) [[2]](diffhunk://#diff-423a6db60de7891cceac2baf1fa96d5f2bc2417f78d456af62b4203ab9db3dcbL276-R280) [[3]](diffhunk://#diff-0cb96f959866b27c62d58185593120f03ae65ade534adeace77611686e8286aaL92-R97)

**Template message construction:**

* The logic for constructing the header component of template messages has been simplified to use the correct media type and the new `mediaId`, ensuring compatibility with WhatsApp requirements.